### PR TITLE
Fixes and ability to create bodies withhout cpSpace.

### DIFF
--- a/generic-chipmunk-plist/GCpShapeCache.h
+++ b/generic-chipmunk-plist/GCpShapeCache.h
@@ -63,6 +63,16 @@
 -(cpBody*) createBodyWithName:(NSString*)name inSpace:(cpSpace*)space withData:(void*)data;
 
 /**
+ * Creates a body with the given name & returns al it's shapes.
+ * Body itself can be accessed through any of the shape->body.
+ * Allows you to create body and shapes without adding it instantly to the space.
+ * @param name name of the body
+ * @param data data to set in the body
+ * @result NSArray with NSValues with pointers to cpShape structures
+ */
+-(NSArray *) shapesOfBodyWithName:(NSString*)name withData: (void *) data;
+
+/**
  * Returns the anchor point of the given sprite
  * @param shape name of the shape to get the anchorpoint for
  * @return anchorpoint

--- a/generic-chipmunk-plist/GCpShapeCache.m
+++ b/generic-chipmunk-plist/GCpShapeCache.m
@@ -451,5 +451,71 @@ typedef enum
     return TRUE;
 }
 
+-(NSArray *) shapesOfBodyWithName:(NSString*)name withData: (void *) data
+{
+    GBodyDef *bd = [bodyDefs objectForKey:name];
+    NSAssert(bd != 0, @"Body not found");
+    if(!bd)
+    {
+        return nil;
+    }
+    
+    // create and add body to space
+    cpBody *body = cpBodyNew(bd->mass, bd->momentum);
+    
+    // set the center point
+    body->p = bd->anchorPoint;
+    
+    // set the data
+    body->data = data;
+    
+    NSMutableArray *shapes = [NSMutableArray arrayWithCapacity: [bd->fixtures count]];
+    
+    // iterate over fixtures
+    for(GFixtureData *fd in bd->fixtures)
+    {
+        if(fd->fixtureType == GFIXTURE_CIRCLE)
+        {
+            cpShape* shape = cpCircleShapeNew(body, fd->radius, fd->center);
+            
+            // set values
+            shape->e = fd->elasticity; 
+            shape->u = fd->friction;
+            shape->surface_v = fd->surfaceVelocity;
+            shape->collision_type = fd->collisionType;
+            shape->group = fd->group;
+            shape->layers = fd->layers;
+            shape->sensor = fd->isSensor;
+            
+            // add shape to resulting array
+            [shapes addObject: [NSValue valueWithPointer: shape]];
+        }
+        else
+        {
+            // iterate over polygons 
+            for(GPolygon *p in fd->polygons)
+            {
+                // create new shape
+                cpShape* shape = cpPolyShapeNew(body, p->numVertices, p->vertices, CGPointZero);
+                
+                // set values
+                shape->e = fd->elasticity; 
+                shape->u = fd->friction;
+                shape->surface_v = fd->surfaceVelocity;
+                shape->collision_type = fd->collisionType;
+                shape->group = fd->group;
+                shape->layers = fd->layers;
+                shape->sensor = fd->isSensor;
+                
+                // add shape to space
+                [shapes addObject: [NSValue valueWithPointer: shape]];
+                
+            }            
+        }        
+    }
+    
+    return shapes;
+}
+
 @end
 

--- a/generic-chipmunk-plist/GCpShapeCache.m
+++ b/generic-chipmunk-plist/GCpShapeCache.m
@@ -404,7 +404,7 @@ typedef enum
                 NSDictionary *circleData = [fixtureData objectForKey:@"circle"];
 
                 fd->radius = [[circleData objectForKey:@"radius"] floatValue];
-                fd->center = CGPointFromString_([fixtureData objectForKey:@"position"]);
+                fd->center = CGPointFromString_([circleData objectForKey:@"position"]);
                 totalArea += 3.1415927*fd->radius*fd->radius;
             }
             else

--- a/main.m
+++ b/main.m
@@ -1,0 +1,17 @@
+//
+//  main.m
+//  pinout-prototype
+//
+//  Created by Stepan Generalov on 30.06.12.
+//  Copyright __MyCompanyName__ 2012. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+int main(int argc, char *argv[]) {
+    
+    NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
+    int retVal = UIApplicationMain(argc, argv, nil, @"Cocos2d_ChipmunkAppDelegate");
+    [pool release];
+    return retVal;
+}


### PR DESCRIPTION
Hi!

1) There was no main.m and i readded it - so it builds now ok.
2) Circle fixtures position was loaded from fixtureData, not circleData - it can look ok, when you have one body with one circle fixture, but when you use large complex bodies with circle fixtures inside - this breaks circle positioning.
3) I have a need of creating bodies & shapes without a knowledge of space they will be added to, so i copy-psated & changed a little createBody, so it returns now shapes, without adding them to space.
So they can be added later like this:

``` objective-c
    cpSpaceAddBody(_space, anObject.body);

    for (NSValue *shapePointerValue in anObject.shapes)
    {
         cpSpaceAddShape(_space, [shapePointerValue pointerValue]);
    }
```

Best Regards,
Stepan
